### PR TITLE
Fix WS-2019-0037, Django-Rest-Framework, before 3.9.1, has a XSS vuln…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ django-bootstrap-form==3.3
 django-bootstrap3==9.0.0
 django-filter==1.0.4
 django-letsencrypt==3.0.0
-djangorestframework==3.7.0
+djangorestframework>=3.9.1
 pytz==2017.3


### PR DESCRIPTION
…erability caused by disabled autoescaping in the default DRF Browsable API view templates.